### PR TITLE
Ignore class

### DIFF
--- a/src/Commands/Schemas.php
+++ b/src/Commands/Schemas.php
@@ -6,7 +6,7 @@ use Tatter\Schemas\Exceptions\SchemasException;
 
 class Schemas extends BaseCommand
 {
-	protected $group       = 'Schemas';
+	protected $group       = 'Database';
 	protected $name        = 'schemas';
 	protected $description = 'Manage database schemas.';
 

--- a/src/Config/Schemas.php
+++ b/src/Config/Schemas.php
@@ -32,6 +32,7 @@ class Schemas extends BaseConfig
 	// Namespaces to ignore (mostly for ModelHandler)
 	public $ignoredNamespaces = [
 		'Tests\Support',
+		'CodeIgniter\Commands\Generators',
 	];
 	
 	// Path the directoryHandler should scan for schema files


### PR DESCRIPTION
Fixes a bug where the `ModelHandler` drafter would detect the framework's `CreateModel` class as a potential model.
