### PR TITLE
ModelHandler - Sort class names by psr-4 namespace sorting.

### DIFF
--- a/src/Drafter/Handlers/ModelHandler.php
+++ b/src/Drafter/Handlers/ModelHandler.php
@@ -141,7 +141,8 @@ class ModelHandler extends BaseDrafter implements DrafterInterface
 		$models  = [];
 
 		// Get each namespace
-		foreach ($loader->getNamespace() as $namespace => $path)
+		$namespaces = $loader->getNamespace();
+		foreach ($namespaces as $namespace => $path)
 		{
 			// Skip namespaces that are ignored
 			if (in_array($namespace, $this->config->ignoredNamespaces))
@@ -162,6 +163,23 @@ class ModelHandler extends BaseDrafter implements DrafterInterface
 
 		// Filter loaded class on likely models
 		$classes = preg_grep('/model$/i', get_declared_classes());
+
+		// Sort classes by namespace order
+		$sortArray = [];
+		foreach ($classes as $class)
+		{
+			foreach (array_keys($namespaces) as $index => $namespace)
+			{
+				// Store the namespace index if it belongs to the class
+				if (strpos($class, $namespace) === 0)
+				{
+					$sortArray[] = $index;
+					continue 2;
+				}
+			}
+			$sortArray[] = -1;
+		}
+		array_multisort($sortArray, SORT_NUMERIC, $classes);
 
 		// Try to load each class
 		foreach ($classes as $class)


### PR DESCRIPTION
This draft aims to make the loading of models during the `draft()` process more constistent and might also be a small start for #7 .

Currently, to merge model names into the schema table, the `ModelHandler` follows this routine:
1. Get all defined namespaces.
2. Load (require) all file containing 'Models' within all namespaces.
3. Get all defined model classes by `get_declared_classes`.
4. Try to instantiate each model class and store the assigned table name. 

This drawback here is, that `get_declared_classes` returns the class names ordered by their time of instantiation.
Therefore, depending on where the `draft()` method is called in the app, Some models will already have loaded (e.g., the 'Myth\Auth\Models\UserModel' when using myth-auth) and the resulting `$classes` array is unordered.

While this is not a problem as long as every table is only assigned to a single model, in the case of multiple models this can lead to inconsistent schema generation, as depending on the models 'pre-loaded' before the draft, different replacements are done (right now, always the last iterated model is stored in the schema table).

This addition sorts the `$classes` array by the order of the namespaces returned from the `autoloader` and hence by the order of the `$psr4` config array. #7 states that multiple models are not supported yet, however, I think this addition might still be valuable in the current state, as behavior is now consistent with the user-defined namespace sorting in the `$psr4` array.
When #7 is implemented in the future, I would think a similar logic will have to be applied to allow for priority ordering.