### PR TITLE
model handler: only try to instantiate what is instantiable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Database schema management, for CodeIgniter 4
 
 ## Quick Start
 
-1. Install with Composer: `> composer require tatter/schemas`
+1. Install with Composer: `> composer require mkuettel/codeigniter4-schemas`
 2. Generate a new schema: `> php spark schemas`
 
 ## Features

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tatter/schemas",
+    "name": "mkuettel/codeigniter4-schemas",
     "description": "Database schema management, for CodeIgniter 4",
     "license": "MIT",
     "type": "library",
@@ -17,9 +17,14 @@
             "email": "mgatner@tattersoftware.com",
             "homepage": "https://tattersoftware.com",
             "role": "Developer"
+        },
+        {
+            "name": "Moritz Küttel",
+            "email": "moritz_kuettel+composer_ci4schemas@tattersoftware.com",
+            "role": "Developer"
         }
     ],
-    "homepage": "https://github.com/tattersoftware/codeigniter4-schemas",
+    "homepage": "https://github.com/mkuettel/codeigniter4-schemas",
     "require": {
         "php": "^7.4 || ^8.0"
     },

--- a/src/Config/Schemas.php
+++ b/src/Config/Schemas.php
@@ -33,7 +33,6 @@ class Schemas extends BaseConfig
 
     // Namespaces to ignore (mostly for ModelHandler)
     public $ignoredNamespaces = [
-        'Tests\Support',
         'CodeIgniter\Commands\Generators',
     ];
 

--- a/src/Drafter/Handlers/ModelHandler.php
+++ b/src/Drafter/Handlers/ModelHandler.php
@@ -168,6 +168,10 @@ class ModelHandler extends BaseDrafter implements DrafterInterface
                 continue;
             }
 
+            if (!(new \ReflectionClass($class))->isInstantiable()) {
+                continue;
+            }
+
             // Try to instantiate
             try {
                 $instance = new $class();


### PR DESCRIPTION
When i was trying to run PHPUnit tests using the database they always instantly failed as soon as a Model with relations got used, because of the automatic scanning which tries to instaniate one of my abstract classes in my project:

  Error: Cannot instantiate abstract class

While there is a try-catch block surrounding the new this will not catch this error, so instead use the RelectionClass is instantiable to check whether the class can be instantiated before doing so.